### PR TITLE
agent: use keyfile settings backend when running as a service

### DIFF
--- a/agent/gaeul-agent.c
+++ b/agent/gaeul-agent.c
@@ -47,7 +47,7 @@ typedef enum
   PROP_LAST
 } _GaeulAgentProperty;
 
-static GParamSpec *properties[PROP_LAST + 1];
+static GParamSpec *properties[PROP_LAST] = { NULL };
 
 struct _GaeulAgent
 {

--- a/agent/gaeul-agent.c
+++ b/agent/gaeul-agent.c
@@ -774,7 +774,7 @@ _settings_map_set_enum (const GValue * value,
 static void
 gaeul_agent_init (GaeulAgent * self)
 {
-  self->settings = g_settings_new (GAEUL_SCHEMA_ID);
+  self->settings = chamge_common_gsettings_new (GAEUL_SCHEMA_ID);
 
   g_settings_bind (self->settings, "edge-id", self, "edge-id",
       G_SETTINGS_BIND_DEFAULT);

--- a/debian/gaeul.service
+++ b/debian/gaeul.service
@@ -3,6 +3,7 @@ Description=Media streamer of Hwansaeul
 
 [Service]
 Type=simple
+Environment=GSETTINGS_BACKEND=keyfile
 ExecStart=/usr/bin/gaeul-agent
 Restart=on-failure
 


### PR DESCRIPTION
Apparently dconf backend needs session D-Bus that system services don't have.

